### PR TITLE
Enable autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ If you only want a certain set of services to be added to the config, specify th
 
 Will add service1 and service2 to the config. Any other services below the current directory will be ignored.
 
+## Autocomplete
+
+To enable bash autocompletion, create a file with the following:
+
+    #! /bin/bash
+
+    : ${PROG:=$(basename ${BASH_SOURCE})}
+
+    _cli_bash_autocomplete() {
+         local cur opts base
+         COMPREPLY=()
+         cur="${COMP_WORDS[COMP_CWORD]}"
+         opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+         return 0
+     }
+      
+     complete -F _cli_bash_autocomplete $PROG
+
+Then source it from your bash profile
+
+    PROG=edward source FILE
+
+Alternatively, name the file edward and place it in your system appropriate `bash_completion.d/` directory.
+ 
 ## sudo
 
 Edward will not run if you try to launch it with sudo, but it may ask you to provide your password so that certain services can be run with elevated priviledges. The password request is triggered through a bash script that calls a command with sudo, to ensure that your bash session can make further sudo calls without prompting.

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	app.Name = "Edward"
 	app.Usage = "Manage local microservices"
 	app.Version = edwardVersion
+	app.EnableBashCompletion = true
 	app.Before = func(c *cli.Context) error {
 		command := c.Args().First()
 
@@ -84,35 +85,41 @@ func main() {
 			Action: generate,
 		},
 		{
-			Name:   "status",
-			Usage:  "Display service status",
-			Action: status,
+			Name:         "status",
+			Usage:        "Display service status",
+			Action:       status,
+			BashComplete: autocompleteServicesAndGroups,
 		},
 		{
-			Name:   "messages",
-			Usage:  "Show messages from services",
-			Action: messages,
+			Name:         "messages",
+			Usage:        "Show messages from services",
+			Action:       messages,
+			BashComplete: autocompleteServicesAndGroups,
 		},
 		{
-			Name:   "start",
-			Usage:  "Build and launch a service",
-			Action: start,
+			Name:         "start",
+			Usage:        "Build and launch a service",
+			Action:       start,
+			BashComplete: autocompleteServicesAndGroups,
 		},
 		{
-			Name:   "stop",
-			Usage:  "Stop a service",
-			Action: stop,
+			Name:         "stop",
+			Usage:        "Stop a service",
+			Action:       stop,
+			BashComplete: autocompleteServicesAndGroups,
 		},
 		{
-			Name:   "restart",
-			Usage:  "Rebuild and relaunch a service",
-			Action: restart,
+			Name:         "restart",
+			Usage:        "Rebuild and relaunch a service",
+			Action:       restart,
+			BashComplete: autocompleteServicesAndGroups,
 		},
 		{
-			Name:    "log",
-			Aliases: []string{"tail"},
-			Usage:   "Tail the log for a service",
-			Action:  doLog,
+			Name:         "log",
+			Aliases:      []string{"tail"},
+			Usage:        "Tail the log for a service",
+			Action:       doLog,
+			BashComplete: autocompleteServices,
 		},
 	}
 
@@ -249,16 +256,43 @@ func getServiceOrGroup(name string) (services.ServiceOrGroup, error) {
 	return nil, errors.New("Service or group not found")
 }
 
-func list(c *cli.Context) error {
-
-	var groupNames []string
+func getAllServices() []string {
 	var serviceNames []string
-	for name := range groupMap {
-		groupNames = append(groupNames, name)
-	}
 	for name := range serviceMap {
 		serviceNames = append(serviceNames, name)
 	}
+	return serviceNames
+}
+
+func getAllGroups() []string {
+	var groupNames []string
+	for name := range groupMap {
+		groupNames = append(groupNames, name)
+	}
+	return groupNames
+
+}
+
+func autocompleteServices(c *cli.Context) {
+	loadConfig()
+	names := getAllServices()
+	for _, name := range names {
+		fmt.Println(name)
+	}
+}
+
+func autocompleteServicesAndGroups(c *cli.Context) {
+	loadConfig()
+	names := append(getAllGroups(), getAllServices()...)
+	for _, name := range names {
+		fmt.Println(name)
+	}
+}
+
+func list(c *cli.Context) error {
+
+	groupNames := getAllGroups()
+	serviceNames := getAllServices()
 
 	sort.Strings(groupNames)
 	sort.Strings(serviceNames)


### PR DESCRIPTION
This enables autocomplete on subcommands and service/group names.

Unfortunately, the user still has to source a file / place it in the autocompletions folder which seems like a major PITA, see https://github.com/urfave/cli#enabling

The file it mentions is in src/github.com/codegansta/cli/autocomplete/