### PR TITLE
Error out properly when restarting an invalid group name

### DIFF
--- a/main.go
+++ b/main.go
@@ -620,8 +620,7 @@ func restart(c *cli.Context) error {
 		restartAll()
 		return nil
 	}
-	restartOneOrMoreServices(c.Args())
-	return nil
+	return restartOneOrMoreServices(c.Args())
 }
 
 func restartAll() error {


### PR DESCRIPTION
Fix for issue #59