### PR TITLE
Expand environment variables in path so $GOPATH still works

### DIFF
--- a/services/command.go
+++ b/services/command.go
@@ -644,10 +644,13 @@ func logToStringSlice(path string) ([]string, error) {
 // if necessary.
 func buildAbsPath(workingDir string, targetPath *string) string {
 	if targetPath != nil {
-		if !path.IsAbs(*targetPath) {
-			return path.Join(workingDir, *targetPath)
+		expandedPath := os.ExpandEnv(*targetPath)
+		if !path.IsAbs(expandedPath) {
+			return path.Join(workingDir, expandedPath)
 		}
+		*targetPath = expandedPath
 		return *targetPath
 	}
 	return workingDir
 }
+


### PR DESCRIPTION
With the new code in the develop branch, the expansion of environment variables in paths no longer works, so this means that things like this will no longer work:

```js
    {
      "name": "service",
      "path": "$GOPATH/src/github.com/my/service",
      "commands": {
        "build": "go install",
        "launch": "service"
      }
    },
```

By adding `os.ExpandEnv`, this will allow it to keep this functionality.