### PR TITLE
Separate service/group control from the models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 before_script:
-  - wget https://github.com/spf13/hugo/releases/download/v0.29/hugo_0.29_Linux-64bit.tar.gz -O /tmp/hugo.tar.gz
+  - wget https://github.com/spf13/hugo/releases/download/v0.32.3/hugo_0.32.3_Linux-64bit.tar.gz -O /tmp/hugo.tar.gz
   - mkdir /tmp/hugo
   - tar -xvf /tmp/hugo.tar.gz -C /tmp/hugo
   - export PATH=$PATH:/tmp/hugo/
@@ -10,7 +10,6 @@ before_install:
   - go get github.com/mitchellh/gox
 
 go:
-  - 1.7
   - 1.8
   - 1.9
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	./build.sh
 
 test:
-	go test -race -cover $(PKGS)
+	go test -timeout 3m -race -cover $(PKGS)
 
 checkdocs:
 	./check_docs.sh

--- a/build.go
+++ b/build.go
@@ -1,6 +1,6 @@
-//+build !go1.7
+//+build !go1.8
 
 package main
 
-// Upgrade to Go version 1.7 to compile edward.
-func init() { Go_version_1_7_required_for_compilation() }
+// Upgrade to Go version 1.8 to compile edward.
+func init() { Go_version_1_8_required_for_compilation() }

--- a/cmd/autocomplete.go
+++ b/cmd/autocomplete.go
@@ -9,10 +9,10 @@ import (
 	"github.com/yext/edward/config"
 )
 
-func autocompleteServicesAndGroups(logger *log.Logger) {
+func autocompleteServicesAndGroups(homeDir string, logger *log.Logger) {
 	printCommandChildren(RootCmd)
 
-	configPath, err := config.GetConfigPathFromWorkingDirectory()
+	configPath, err := config.GetConfigPathFromWorkingDirectory(homeDir)
 	if err != nil {
 		logger.Println("Autocomplete> Error getting config path:", err)
 		return

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,11 +18,12 @@ var runCmd = &cobra.Command{
 			return fmt.Errorf("service not found: %s", args[0])
 		}
 		r := &runner.Runner{
-			Service: service,
+			Service:   service,
+			DirConfig: edwardClient.DirConfig,
 		}
 		r.NoWatch = *runFlags.noWatch
 		r.WorkingDir = *runFlags.directory
-		r.Logger = logger
+		r.Logger = edwardClient.Logger
 		err := r.Run(args)
 		return errors.WithStack(err)
 	},

--- a/config/load.go
+++ b/config/load.go
@@ -7,23 +7,22 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"github.com/yext/edward/home"
 )
 
-func GetConfigPathFromWorkingDirectory() (string, error) {
+func GetConfigPathFromWorkingDirectory(homeDir string) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	return GetConfigPath(wd), nil
+	return GetConfigPath(homeDir, wd), nil
 }
 
 // GetConfigPath identifies the location of edward.json, if any exists
-func GetConfigPath(wd string) string {
+func GetConfigPath(homeDir string, wd string) string {
 	var pathOptions []string
 
 	// Config file in Edward Config dir
-	pathOptions = append(pathOptions, filepath.Join(home.EdwardConfig.Dir, "edward.json"))
+	pathOptions = append(pathOptions, filepath.Join(homeDir, "edward.json"))
 
 	// Config file in current working directory
 	pathOptions = append(pathOptions, filepath.Join(wd, "edward.json"))

--- a/docs/autocompletion/index.html
+++ b/docs/autocompletion/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>Autocompletion - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -400,7 +400,7 @@ _cli_bash_autocomplete() {
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/commands/index.html
+++ b/docs/commands/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>Commands - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -588,7 +588,7 @@ at least one port. If a service does not listen on any ports, it will time out w
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>About Edward</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -411,7 +411,7 @@ as and when you need with <code>edward log</code></p>
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>Getting started - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -400,7 +400,7 @@ advising you to update.</p>
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/license/index.html
+++ b/docs/license/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>License - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -397,7 +397,7 @@ SOFTWARE.</p>
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/projectconfig/index.html
+++ b/docs/projectconfig/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>Project Configuration - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -652,7 +652,7 @@ config files.</p>
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/quickstart/index.html
+++ b/docs/quickstart/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>Getting started - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -647,7 +647,7 @@ the alias <code>edward tail</code>.</p>
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/roadmap/index.html
+++ b/docs/roadmap/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>Roadmap - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -394,7 +394,7 @@
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/docs/sudo/index.html
+++ b/docs/sudo/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>Sudo - Edward Docs</title>
-    <meta name="generator" content="Hugo 0.29" />
+    <meta name="generator" content="Hugo 0.32.3" />
 
     
     <meta name="description" content="A command line tool for managing local instances of microservices.">
@@ -379,7 +379,7 @@
 
 			<aside class="copyright" role="note">
 				
-				&copy; 2017 Released under the MIT license &ndash;
+				&copy; 2018 Released under the MIT license &ndash;
 				
 				Documentation built with
 				<a href="https://www.gohugo.io" target="_blank">Hugo</a>

--- a/edward/client.go
+++ b/edward/client.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/yext/edward/builder"
+	"github.com/yext/edward/home"
+	"github.com/yext/edward/instance"
 	"github.com/yext/edward/output"
 	"github.com/yext/edward/services"
 	"github.com/yext/edward/tracker"
@@ -42,6 +45,8 @@ type Client struct {
 	serviceMap map[string]*services.ServiceConfig
 
 	Tags []string // Tags to distinguish runners started by this instance of edward
+
+	DirConfig *home.EdwardConfiguration
 }
 
 type TaskFollower interface {
@@ -56,6 +61,11 @@ func NewClient() (*Client, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	dirCfg, err := home.NewConfiguration()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
 	return &Client{
 		Input:      os.Stdin,
 		Output:     os.Stdout,
@@ -64,12 +74,18 @@ func NewClient() (*Client, error) {
 		WorkingDir: wd,
 		groupMap:   make(map[string]*services.ServiceGroupConfig),
 		serviceMap: make(map[string]*services.ServiceConfig),
+		DirConfig:  dirCfg,
 	}, nil
 }
 
 // NewClientWithConfig creates an Edward client and loads the config from the given path
 func NewClientWithConfig(configPath, version string, logger *log.Logger) (*Client, error) {
 	wd, err := os.Getwd()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	dirCfg, err := home.NewConfiguration()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -83,6 +99,7 @@ func NewClientWithConfig(configPath, version string, logger *log.Logger) (*Clien
 		Config:     configPath,
 		groupMap:   make(map[string]*services.ServiceGroupConfig),
 		serviceMap: make(map[string]*services.ServiceConfig),
+		DirConfig:  dirCfg,
 	}
 	err = client.LoadConfig(version)
 	return client, errors.WithStack(err)
@@ -121,21 +138,30 @@ func (c *Client) startAndTrack(sgs []services.ServiceOrGroup, skipBuild bool, ta
 		_ = <-p.Complete()
 	}()
 	var err error
-	for _, s := range sgs {
+	err = services.DoForServices(sgs, task, func(s *services.ServiceConfig, overrides services.ContextOverride, task tracker.Task) error {
 		if skipBuild {
 			c.Logger.Println("skipping build phase")
-			err = s.Launch(cfg, services.ContextOverride{}, task, p)
+			err = instance.Launch(c.DirConfig, s, cfg, overrides, task, p)
 			if err != nil {
 				return errors.WithMessage(err, "Error launching "+s.GetName())
 			}
 		} else {
-			err = s.Start(cfg, services.ContextOverride{}, task, p)
-			if err != nil {
-				return errors.WithMessage(err, "Error starting "+s.GetName())
+			if cfg.IsExcluded(s) {
+				return nil
 			}
+			c.Logger.Printf("Building: %s", s.Name)
+			b := builder.New(cfg, overrides)
+			err := b.Build(c.DirConfig, task, s)
+			if err != nil {
+				return errors.WithMessage(err, "Error starting "+s.GetName()+": build")
+			}
+			c.Logger.Printf("Launching: %s", s.Name)
+			err = instance.Launch(c.DirConfig, s, cfg, overrides, task, p)
+			return errors.WithMessage(err, "Error starting "+s.GetName()+": launch")
 		}
-	}
-	return nil
+		return nil
+	})
+	return errors.WithStack(err)
 }
 
 func (c *Client) tailFromFlag(names []string) error {
@@ -168,18 +194,4 @@ func (c *Client) askForConfirmation(question string) bool {
 			return false
 		}
 	}
-}
-
-type serviceConfigByPID []*services.ServiceConfig
-
-func (s serviceConfigByPID) Len() int {
-	return len(s)
-}
-func (s serviceConfigByPID) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s serviceConfigByPID) Less(i, j int) bool {
-	cmd1, _ := s[i].GetCommand(services.ContextOverride{})
-	cmd2, _ := s[j].GetCommand(services.ContextOverride{})
-	return cmd1.Pid < cmd2.Pid
 }

--- a/edward/client_test.go
+++ b/edward/client_test.go
@@ -71,7 +71,6 @@ func (f *testFollower) Done() {}
 
 // getRunnerAndServiceProcesses returns all processes and children spawned by this test
 func getRunnerAndServiceProcesses(t *testing.T) []*process.Process {
-	t.Helper()
 	var processes []*process.Process
 	testProcess, err := process.NewProcess(int32(os.Getpid()))
 	if err != nil {

--- a/edward/copy_test.go
+++ b/edward/copy_test.go
@@ -7,12 +7,55 @@ import (
 	"log"
 	"os"
 	"path"
-	"testing"
+	"path/filepath"
+	"time"
+
+	"github.com/yext/edward/common"
+	"github.com/yext/edward/home"
+
+	"github.com/yext/edward/edward"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
+
+func createClient(configFile, testName, testPath string) (*edward.Client, string, func(), error) {
+	// Copy test content into a temp dir on the GOPATH & defer deletion
+	wd, cleanup, err := createWorkingDir(testName, testPath)
+	if err != nil {
+		return nil, "", func() {}, err
+	}
+
+	dirConfig := &home.EdwardConfiguration{}
+	err = dirConfig.InitializeWithDir(path.Join(wd, "edwardHome"))
+	if err != nil {
+		return nil, "", func() {}, err
+	}
+
+	client, err := edward.NewClientWithConfig(
+		path.Join(wd, configFile),
+		common.EdwardVersion,
+		log.New(&lumberjack.Logger{
+			Filename:   filepath.Join(dirConfig.EdwardLogDir, "edward.log"),
+			MaxSize:    50, // megabytes
+			MaxBackups: 30,
+			MaxAge:     1, //days
+		}, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile),
+	)
+	if err != nil {
+		return nil, "", func() {}, err
+	}
+
+	client.DirConfig = dirConfig
+	client.EdwardExecutable = edwardExecutable
+	client.DisableConcurrentPhases = true
+	client.WorkingDir = wd
+	client.Tags = []string{fmt.Sprintf("test.%d", time.Now().UnixNano())}
+
+	return client, wd, cleanup, nil
+}
 
 // createWorkingDir creates a directory to work in and changes into that directory.
 // Returns a cleanup function.
-func createWorkingDir(t *testing.T, testName, testPath string) (string, func()) {
+func createWorkingDir(testName, testPath string) (string, func(), error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
@@ -23,12 +66,12 @@ func createWorkingDir(t *testing.T, testName, testPath string) (string, func()) 
 	}
 	workingDir, err := ioutil.TempDir(workingPath, testName)
 	if err != nil {
-		t.Fatal(err)
+		return "", func() {}, err
 	}
 	copy_folder(testPath, workingDir)
 	return workingDir, func() {
 		os.RemoveAll(workingDir)
-	}
+	}, nil
 }
 
 func copy_folder(source string, dest string) (err error) {
@@ -56,12 +99,12 @@ func copy_folder(source string, dest string) (err error) {
 		if obj.IsDir() {
 			err = copy_folder(sourcefilepointer, destinationfilepointer)
 			if err != nil {
-				fmt.Println("Copying folder:",err)
+				fmt.Println("Copying folder:", err)
 			}
 		} else {
 			err = copy_file(sourcefilepointer, destinationfilepointer)
 			if err != nil {
-				fmt.Println("Copying file:",err)
+				fmt.Println("Copying file:", err)
 			}
 		}
 

--- a/edward/generate_test.go
+++ b/edward/generate_test.go
@@ -127,12 +127,17 @@ Do you wish to continue? [y/n]? Wrote to: ${TMP_PATH}/edward.json
 			var err error
 
 			// Copy test content into a temp dir on the GOPATH & defer deletion
-			wd, cleanup := createWorkingDir(t, test.name, test.path)
+			wd, cleanup, err := createWorkingDir(test.name, test.path)
+			if err != nil {
+				t.Errorf("Error building working dir: %v", err)
+				return
+			}
 			defer cleanup()
 
 			client, err := edward.NewClient()
 			if err != nil {
-				t.Fatal(err)
+				t.Errorf("Error building client: %v", err)
+				return
 			}
 			client.EdwardExecutable = edwardExecutable
 			client.DisableConcurrentPhases = true
@@ -168,6 +173,7 @@ Do you wish to continue? [y/n]? Wrote to: ${TMP_PATH}/edward.json
 			}()
 
 			err = client.Generate(test.services, test.force, test.group, test.targets)
+
 			inputWriter.Close()
 			outputWriter.Close()
 			must.BeEqualErrors(t, test.err, err)

--- a/edward/restart_test.go
+++ b/edward/restart_test.go
@@ -1,20 +1,12 @@
 package edward_test
 
 import (
-	"errors"
-	"fmt"
-	"log"
 	"os"
-	"path"
-	"path/filepath"
 	"syscall"
 	"testing"
-	"time"
 
+	"github.com/pkg/errors"
 	"github.com/theothertomelliott/must"
-	"github.com/yext/edward/common"
-	"github.com/yext/edward/edward"
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestRestart(t *testing.T) {
@@ -87,28 +79,12 @@ func TestRestart(t *testing.T) {
 			var err error
 
 			// Copy test content into a temp dir on the GOPATH & defer deletion
-			wd, cleanup := createWorkingDir(t, test.name, test.path)
+			client, wd, cleanup, err := createClient(test.config, test.name, test.path)
 			defer cleanup()
+			defer showLogsIfFailed(t, test.name, wd, client)
 
-			client, err := edward.NewClientWithConfig(
-				path.Join(wd, test.config),
-				common.EdwardVersion,
-				log.New(&lumberjack.Logger{
-					Filename:   filepath.Join(wd, "edward.log"),
-					MaxSize:    50, // megabytes
-					MaxBackups: 30,
-					MaxAge:     1, //days
-				}, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile),
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			client.WorkingDir = wd
 			tf := newTestFollower()
 			client.Follower = tf
-			client.EdwardExecutable = edwardExecutable
-			client.DisableConcurrentPhases = true
-			client.Tags = []string{fmt.Sprintf("test.restart.%d", time.Now().UnixNano())}
 
 			err = client.Start(test.servicesStart, test.skipBuild, false, test.noWatch, test.exclude)
 			if err != nil {

--- a/edward/runner_test.go
+++ b/edward/runner_test.go
@@ -1,0 +1,86 @@
+package edward_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+	"time"
+)
+
+func TestLogOutput(t *testing.T) {
+	runnerTest(t, func(wd string, success chan struct{}) {
+		homeDir := path.Join(wd, "edward_home")
+		expectedLog := path.Join(homeDir, "edward_logs")
+		expectedLog = path.Join(expectedLog, "edward.log")
+		fmt.Println("Expecting log file at:", expectedLog)
+		for true {
+			if _, err := os.Stat(expectedLog); !os.IsNotExist(err) {
+				success <- struct{}{}
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	})
+}
+
+func TestStatusFile(t *testing.T) {
+	runnerTest(t, func(wd string, success chan struct{}) {
+		homeDir := path.Join(wd, "edward_home")
+		statusDir := path.Join(homeDir, "stateFiles")
+		fmt.Println("Expecting status file under:", statusDir)
+		for true {
+			files, _ := ioutil.ReadDir(statusDir)
+			if len(files) > 0 {
+				success <- struct{}{}
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	})
+}
+
+func runnerTest(t *testing.T, f func(string, chan struct{})) {
+	wd, cleanup, err := createWorkingDir("TestLogOutput", "testdata/buildless")
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	homeDir := path.Join(wd, "edward_home")
+
+	cmd := exec.Command(edwardExecutable,
+		"--edward_home", homeDir,
+		"-c", path.Join(wd, "edward.json"),
+		"run",
+		"service",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	logFound := make(chan struct{})
+	go f(wd, logFound)
+	select {
+	case <-time.After(3 * time.Second):
+		if err := cmd.Process.Kill(); err != nil {
+			t.Error("failed to kill process: ", err)
+		}
+		t.Error("timed out before success condition")
+	case err := <-done:
+		if err != nil {
+			t.Errorf("process exited with error = %v", err)
+		} else {
+			t.Error("process exited before success condition")
+		}
+	case <-logFound:
+		return
+	}
+}

--- a/edward/status.go
+++ b/edward/status.go
@@ -11,7 +11,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/theothertomelliott/gopsutil-nocgo/process"
-	"github.com/yext/edward/home"
 	"github.com/yext/edward/instance"
 	"github.com/yext/edward/services"
 )
@@ -89,15 +88,15 @@ func (c *Client) Status(names []string, all bool) (string, error) {
 
 type statusCommandTuple struct {
 	status  instance.Status
-	command *services.ServiceCommand
+	command *instance.Instance
 }
 
 func (c *Client) getStates(service *services.ServiceConfig) ([]statusCommandTuple, error) {
-	command, err := service.GetCommand(services.ContextOverride{})
+	command, err := instance.Load(c.DirConfig, service, services.ContextOverride{})
 	if err != nil {
 		return nil, errors.WithMessage(err, "could not get service command")
 	}
-	statuses, _ := instance.LoadStatusForService(service, home.EdwardConfig.StateDir)
+	statuses, _ := instance.LoadStatusForService(service, c.DirConfig.StateDir)
 	if status, ok := statuses[command.InstanceId]; ok {
 		return []statusCommandTuple{
 			statusCommandTuple{
@@ -114,7 +113,7 @@ func (c *Client) getServiceList(names []string, all bool) ([]services.ServiceOrG
 	var err error
 
 	if all {
-		runningServices, err := services.LoadRunningServices()
+		runningServices, err := instance.LoadRunningServices(c.DirConfig.StateDir)
 		if err != nil {
 			return nil, err
 		}

--- a/edward/status_test.go
+++ b/edward/status_test.go
@@ -1,21 +1,17 @@
 package edward_test
 
 import (
-	"fmt"
-	"log"
-	"path"
-	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/theothertomelliott/must"
-	"github.com/yext/edward/common"
-	"github.com/yext/edward/edward"
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	var tests = []struct {
 		name             string
 		path             string
@@ -69,29 +65,11 @@ func TestStatus(t *testing.T) {
 			var err error
 
 			// Copy test content into a temp dir on the GOPATH & defer deletion
-			wd, cleanup := createWorkingDir(t, test.name, test.path)
+			client, _, cleanup, err := createClient(test.config, test.name, test.path)
 			defer cleanup()
 
-			client, err := edward.NewClientWithConfig(
-				path.Join(wd, test.config),
-				common.EdwardVersion,
-				log.New(&lumberjack.Logger{
-					Filename:   filepath.Join(wd, "edward.log"),
-					MaxSize:    50, // megabytes
-					MaxBackups: 30,
-					MaxAge:     1, //days
-				}, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile),
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			client.WorkingDir = wd
 			tf := newTestFollower()
 			client.Follower = tf
-
-			client.EdwardExecutable = edwardExecutable
-			client.DisableConcurrentPhases = true
-			client.Tags = []string{fmt.Sprintf("test.status.%d", time.Now().UnixNano())}
 
 			err = client.Start(test.runningServices, false, false, false, nil)
 			if err != nil {

--- a/edward/stop_test.go
+++ b/edward/stop_test.go
@@ -1,21 +1,11 @@
 package edward_test
 
 import (
-	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
-	"path"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/theothertomelliott/must"
-	"github.com/yext/edward/common"
-	"github.com/yext/edward/edward"
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestStopAll(t *testing.T) {
@@ -95,39 +85,15 @@ func TestStopAll(t *testing.T) {
 			var err error
 
 			// Copy test content into a temp dir on the GOPATH & defer deletion
-			wd, cleanup := createWorkingDir(t, test.name, test.path)
+			client, wd, cleanup, err := createClient(test.config, test.name, test.path)
 			defer cleanup()
+			defer showLogsIfFailed(t, test.name, wd, client)
 
-			client, err := edward.NewClientWithConfig(
-				path.Join(wd, test.config),
-				common.EdwardVersion,
-				log.New(&lumberjack.Logger{
-					Filename:   filepath.Join(wd, "edward.log"),
-					MaxSize:    50, // megabytes
-					MaxBackups: 30,
-					MaxAge:     1, //days
-				}, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile),
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// TODO: Configure the client to set the runner's log file to the same as Logger above.
-			client.WorkingDir = wd
 			tf := newTestFollower()
 			client.Follower = tf
 
-			client.EdwardExecutable = edwardExecutable
-			client.DisableConcurrentPhases = true
-			client.Tags = []string{fmt.Sprintf("test.stop.%d", time.Now().UnixNano())}
-
 			err = client.Start(test.servicesStart, test.skipBuild, false, test.noWatch, test.exclude)
 			if err != nil {
-				b, err := ioutil.ReadFile(filepath.Join(wd, "edward.log"))
-				if err != nil {
-					t.Fatal(err)
-				}
-				fmt.Print("=== Log ===\n", string(b), "=== /Log ===\n")
-				fmt.Println("=== Messages ===\n", strings.Join(tf.messages, "\n"), "\n=== /Messages ===")
 				t.Fatal(err)
 			}
 

--- a/edward/testdata/buildless/edward-test-service/main.go
+++ b/edward/testdata/buildless/edward-test-service/main.go
@@ -1,0 +1,37 @@
+// A simple executable that stays runnning until an interrupt is received
+// Based on: https://gobyexample.com/signals
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello: %s!", r.URL.Path[1:])
+	})
+
+	go func() {
+		log.Fatal(http.ListenAndServe(":0", nil))
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+
+	select {
+	case <-stop:
+		fmt.Println("Terminated")
+	case <-timer.C:
+		fmt.Println("Timed out")
+	}
+
+	fmt.Println("Exiting")
+}

--- a/edward/testdata/buildless/edward.json
+++ b/edward/testdata/buildless/edward.json
@@ -1,0 +1,11 @@
+{
+    "services": [
+        {
+            "name": "service",
+            "path": "edward-test-service",
+            "commands": {
+                "launch": "go run main.go"
+            }
+        }
+    ]
+}

--- a/edward/testdata/features/edward.json
+++ b/edward/testdata/features/edward.json
@@ -7,7 +7,7 @@
             ],
             "env": [
                 "BUILD=build",
-                "PORT=51937",
+                "PORT=51938",
                 "APPLIED=YES"
             ]
         }
@@ -48,10 +48,7 @@
             "commands": {
                 "build": "go ${BUILD}",
                 "launch": "./edward-test-expectenv ${PORT}"
-            },
-            "env": [
-                "APPLIED=YES"
-            ]
+            }
         },
         {
             "name": "wait",

--- a/edward/testdata/launchfailure/edward.json
+++ b/edward/testdata/launchfailure/edward.json
@@ -25,7 +25,14 @@
             "path": "edward-test-service-broken",
             "commands": {
                 "build": "go build -o edward-test-service-broken",
-                "launch": "./edward-test-service2 51937"
+                "launch": "./edward-test-service-broken 51937"
+            }
+        },
+        {
+            "name": "badcommand",
+            "path": "edward-test-service-broken",
+            "commands": {
+                "launch": "./edward-test-service-not-exist 51937"
             }
         }
     ]

--- a/home/home.go
+++ b/home/home.go
@@ -18,13 +18,19 @@ type EdwardConfiguration struct {
 	ScriptDir    string
 }
 
-// EdwardConfig stores a shared instance of EdwardConfiguration for use across the app
-var EdwardConfig = EdwardConfiguration{}
-
 func createDirIfNeeded(path string) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		os.MkdirAll(path, 0777)
 	}
+}
+
+func NewConfiguration() (*EdwardConfiguration, error) {
+	cfg := &EdwardConfiguration{}
+	err := cfg.Initialize()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return cfg, nil
 }
 
 // Initialize sets up EdwardConfig based on the location of .edward in the home dir
@@ -33,7 +39,11 @@ func (e *EdwardConfiguration) Initialize() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	e.Dir = path.Join(user.HomeDir, ".edward")
+	return e.InitializeWithDir(path.Join(user.HomeDir, ".edward"))
+}
+
+func (e *EdwardConfiguration) InitializeWithDir(dir string) error {
+	e.Dir = dir
 	createDirIfNeeded(e.Dir)
 	e.EdwardLogDir = path.Join(e.Dir, "edward_logs")
 	createDirIfNeeded(e.EdwardLogDir)

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -300,12 +300,8 @@ func (c *Instance) RunStopScript(workingDir string) ([]byte, error) {
 
 func (c *Instance) clearPid() {
 	c.Pid = 0
-	var err error
 	_ = os.Remove(c.Service.GetPidPathLegacy(c.dirConfig.PidDir))
-	err = os.Remove(c.Service.GetStatePath(c.dirConfig.StateDir))
-	if err != nil {
-		panic(err)
-	}
+	_ = os.Remove(c.Service.GetStatePath(c.dirConfig.StateDir))
 }
 
 func (c *Instance) clearState() {

--- a/instance/loadrunning.go
+++ b/instance/loadrunning.go
@@ -1,4 +1,4 @@
-package services
+package instance
 
 import (
 	"encoding/json"
@@ -6,24 +6,23 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
-	"github.com/yext/edward/home"
+	"github.com/yext/edward/services"
 )
 
-func LoadRunningServices() ([]ServiceOrGroup, error) {
-	dir := home.EdwardConfig.StateDir
-	stateFiles, err := ioutil.ReadDir(dir)
+func LoadRunningServices(stateDir string) ([]services.ServiceOrGroup, error) {
+	stateFiles, err := ioutil.ReadDir(stateDir)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	var services []ServiceOrGroup
+	var services []services.ServiceOrGroup
 	for _, file := range stateFiles {
 		// Skip directories (these contain instance state)
 		if file.IsDir() {
 			continue
 		}
 
-		command := &ServiceCommand{}
-		raw, err := ioutil.ReadFile(path.Join(dir, file.Name()))
+		command := &Instance{}
+		raw, err := ioutil.ReadFile(path.Join(stateDir, file.Name()))
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/instance/running.go
+++ b/instance/running.go
@@ -2,12 +2,13 @@ package instance
 
 import (
 	"github.com/pkg/errors"
+	"github.com/yext/edward/home"
 	"github.com/yext/edward/services"
 )
 
 // HasRunning returns true iff the specified service has a currently running instance
-func HasRunning(service *services.ServiceConfig) (bool, error) {
-	command, err := service.GetCommand(services.ContextOverride{})
+func HasRunning(dirConfig *home.EdwardConfiguration, service *services.ServiceConfig) (bool, error) {
+	command, err := Load(dirConfig, service, services.ContextOverride{})
 	if err != nil {
 		return false, errors.WithStack(err)
 	}

--- a/instance/start.go
+++ b/instance/start.go
@@ -1,0 +1,26 @@
+package instance
+
+import (
+	"github.com/pkg/errors"
+	"github.com/yext/edward/home"
+	"github.com/yext/edward/services"
+	"github.com/yext/edward/tracker"
+	"github.com/yext/edward/worker"
+)
+
+// Launch launches this service
+func Launch(dirConfig *home.EdwardConfiguration, c *services.ServiceConfig, cfg services.OperationConfig, overrides services.ContextOverride, task tracker.Task, pool *worker.Pool) error {
+	if cfg.IsExcluded(c) {
+		return nil
+	}
+
+	instance, err := Load(dirConfig, c, overrides)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = pool.Enqueue(func() error {
+		return errors.WithStack(instance.StartAsync(cfg, task))
+	})
+	return errors.WithStack(err)
+}

--- a/instance/state.go
+++ b/instance/state.go
@@ -35,13 +35,15 @@ type Status struct {
 var store = make(map[string]Status)
 
 func LoadStatusForService(service *services.ServiceConfig, baseDir string) (map[string]Status, error) {
+	var statuses = make(map[string]Status)
 	statusDir := statusDir(service, baseDir)
+	if _, err := os.Stat(statusDir); os.IsNotExist(err) {
+		return statuses, nil
+	}
 	files, err := ioutil.ReadDir(statusDir)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
-	var statuses = make(map[string]Status)
 	for _, f := range files {
 		raw, err := ioutil.ReadFile(path.Join(statusDir, f.Name()))
 		if err != nil {
@@ -81,6 +83,15 @@ func SaveStatusForService(service *services.ServiceConfig, instanceId string, st
 		return errors.WithMessage(err, "save status")
 	}
 	return nil
+}
+
+func DeleteAllStatusesForService(service *services.ServiceConfig, baseDir string) error {
+	statusDir := statusDir(service, baseDir)
+	if _, err := os.Stat(statusDir); os.IsNotExist(err) {
+		return nil
+	}
+	err := os.RemoveAll(statusDir)
+	return errors.WithStack(err)
 }
 
 func DeleteStatusForService(service *services.ServiceConfig, instanceId, baseDir string) error {

--- a/instance/state_test.go
+++ b/instance/state_test.go
@@ -100,3 +100,51 @@ func TestDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteAll(t *testing.T) {
+	var tests = []struct {
+		name             string
+		service          *services.ServiceConfig
+		instanceStatuses map[string]instance.Status
+	}{
+		{
+			name: "single status",
+			service: &services.ServiceConfig{
+				Name:       "testService",
+				ConfigFile: "/path/to/config/file",
+			},
+			instanceStatuses: map[string]instance.Status{
+				"test": instance.Status{
+					State: instance.StateStarting,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testDir, err := ioutil.TempDir("", test.name)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(testDir)
+
+			for identifier, status := range test.instanceStatuses {
+				err := instance.SaveStatusForService(test.service, identifier, status, testDir)
+				if err != nil {
+					t.Errorf("error saving status: %v", err)
+				}
+			}
+
+			err = instance.DeleteAllStatusesForService(test.service, testDir)
+			if err != nil {
+				t.Errorf("error deleting status: %v", err)
+			}
+
+			got, err := instance.LoadStatusForService(test.service, testDir)
+			if err != nil {
+				t.Errorf("error loading status: %v", err)
+			}
+			must.BeEqual(t, 0, len(got))
+		})
+	}
+}

--- a/instance/stop.go
+++ b/instance/stop.go
@@ -1,0 +1,21 @@
+package instance
+
+import (
+	"github.com/pkg/errors"
+	"github.com/yext/edward/home"
+	"github.com/yext/edward/services"
+	"github.com/yext/edward/tracker"
+	"github.com/yext/edward/worker"
+)
+
+// Stop stops this service
+func Stop(dirConfig *home.EdwardConfiguration, c *services.ServiceConfig, cfg services.OperationConfig, overrides services.ContextOverride, task tracker.Task, pool *worker.Pool) error {
+	instance, err := Load(dirConfig, c, overrides)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	err = pool.Enqueue(func() error {
+		return errors.WithStack(instance.StopSync(cfg, overrides, task))
+	})
+	return errors.WithStack(err)
+}

--- a/instance/wait.go
+++ b/instance/wait.go
@@ -23,6 +23,14 @@ func WaitUntilRunning(dirCfg *home.EdwardConfiguration, cmd *exec.Cmd, service *
 	case err := <-errChan:
 		return errors.WithStack(err)
 	case <-exitChan:
+		statuses, err := LoadStatusForService(service, dirCfg.StateDir)
+		if err == nil {
+			for _, status := range statuses {
+				if status.State == StateDied || status.State == StateStopped {
+					return fmt.Errorf("exited with state: %v", status.State)
+				}
+			}
+		}
 		return errors.New("runner process exited")
 	}
 }

--- a/instance/wait.go
+++ b/instance/wait.go
@@ -1,0 +1,87 @@
+package instance
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/yext/edward/home"
+
+	"github.com/pkg/errors"
+	"github.com/theothertomelliott/gopsutil-nocgo/net"
+	"github.com/yext/edward/services"
+)
+
+// WaitUntilRunning will block the specified service until it enters the running state
+func WaitUntilRunning(dirCfg *home.EdwardConfiguration, cmd *exec.Cmd, service *services.ServiceConfig) error {
+	runningChan, errChan := statusRunningChan(dirCfg, service)
+	exitChan := commandExitChan(cmd)
+
+	select {
+	case <-runningChan:
+		return nil
+	case err := <-errChan:
+		return errors.WithStack(err)
+	case <-exitChan:
+		return errors.New("runner process exited")
+	}
+}
+
+func statusRunningChan(dirCfg *home.EdwardConfiguration, service *services.ServiceConfig) (runningChan chan struct{}, errChan chan error) {
+	runningChan = make(chan struct{})
+	errChan = make(chan error)
+
+	go func() {
+		for true {
+			time.Sleep(time.Millisecond)
+			statuses, err := LoadStatusForService(service, dirCfg.StateDir)
+			if err != nil {
+				continue
+			}
+			for _, status := range statuses {
+				if status.State == StateDied || status.State == StateStopped {
+					errChan <- fmt.Errorf("exited with state: %v", status.State)
+					return
+				}
+				if status.State == StateRunning {
+					close(runningChan)
+					return
+				}
+			}
+		}
+	}()
+
+	return runningChan, errChan
+}
+
+func commandExitChan(cmd *exec.Cmd) chan struct{} {
+	out := make(chan struct{})
+	go func() {
+		cmd.Wait()
+		close(out)
+	}()
+	return out
+}
+
+const portStatusListen = "LISTEN"
+
+func (c *Instance) areAnyListeningPortsOpen(ports []int) (bool, error) {
+
+	var matchedPorts = make(map[int]struct{})
+	for _, port := range ports {
+		matchedPorts[port] = struct{}{}
+	}
+
+	connections, err := net.Connections("all")
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	for _, connection := range connections {
+		if connection.Status == portStatusListen {
+			if _, ok := matchedPorts[int(connection.Laddr.Port)]; ok {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/runner/wait.go
+++ b/runner/wait.go
@@ -1,39 +1,47 @@
-package services
+package runner
 
 import (
-	"os/exec"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/yext/edward/home"
 
 	"github.com/hpcloud/tail"
 	"github.com/pkg/errors"
 	"github.com/theothertomelliott/gopsutil-nocgo/net"
 	"github.com/theothertomelliott/gopsutil-nocgo/process"
+	"github.com/yext/edward/instance"
+	"github.com/yext/edward/services"
 )
 
 // WaitUntilLive blocks until a command running the specified service is in the RUNNING state.
 // An error will be returned if the command exits before reaching RUNNING.
-func WaitUntilLive(command *exec.Cmd, service *ServiceConfig) error {
-
-	service.printf("Waiting for %v to start.\n", service.Name)
+func WaitUntilLive(dirConfig *home.EdwardConfiguration, pid int32, service *services.ServiceConfig) error {
+	logger := service.Logger
+	fmt.Println("Wait until live")
+	logger.Printf("Waiting for %v to start.\n", service.Name)
 
 	var startCheck func(cancel <-chan struct{}) error
 	if service.LaunchChecks != nil && len(service.LaunchChecks.LogText) > 0 {
-		service.printf("Waiting for log text: %v", service.LaunchChecks.LogText)
+		fmt.Printf("Waiting for log text: %v", service.LaunchChecks.LogText)
+		logger.Printf("Waiting for log text: %v", service.LaunchChecks.LogText)
 		startCheck = func(cancel <-chan struct{}) error {
 			return errors.WithStack(
-				waitForLogText(service.LaunchChecks.LogText, cancel, service),
+				waitForLogText(dirConfig, service.LaunchChecks.LogText, cancel, service),
 			)
 		}
 	} else if service.LaunchChecks != nil && len(service.LaunchChecks.Ports) > 0 {
-		service.printf("Waiting for ports: %v", service.LaunchChecks.Ports)
+		fmt.Printf("Waiting for log text: %v", service.LaunchChecks.LogText)
+		logger.Printf("Waiting for log text: %v", service.LaunchChecks.LogText)
 		startCheck = func(cancel <-chan struct{}) error {
 			return errors.WithStack(
-				waitForListeningPorts(service.LaunchChecks.Ports, cancel, command),
+				waitForListeningPorts(service.LaunchChecks.Ports, cancel, pid),
 			)
 		}
 	} else if service.LaunchChecks != nil && service.LaunchChecks.Wait != 0 {
-		service.printf("Waiting for: %dms", service.LaunchChecks.Wait)
+		fmt.Printf("Waiting for: %dms", service.LaunchChecks.Wait)
+		logger.Printf("Waiting for: %dms", service.LaunchChecks.Wait)
 		startCheck = func(cancel <-chan struct{}) error {
 			delay := time.NewTimer(time.Duration(service.LaunchChecks.Wait) * time.Millisecond)
 			defer delay.Stop()
@@ -45,23 +53,13 @@ func WaitUntilLive(command *exec.Cmd, service *ServiceConfig) error {
 			}
 		}
 	} else {
-		service.printf("Waiting for any port")
+		fmt.Printf("Waiting for any port\n")
+		logger.Printf("Waiting for any port")
 		startCheck = func(cancel <-chan struct{}) error {
 			return errors.WithStack(
-				waitForAnyPort(cancel, command),
+				waitForAnyPort(cancel, pid),
 			)
 		}
-	}
-
-	processFinished := func(cancel <-chan struct{}) error {
-		// Wait until the process exists
-		command.Wait()
-		select {
-		case <-cancel:
-			return nil
-		default:
-		}
-		return errors.New("service terminated prematurely")
 	}
 
 	done := make(chan struct{})
@@ -69,20 +67,17 @@ func WaitUntilLive(command *exec.Cmd, service *ServiceConfig) error {
 
 	select {
 	case result := <-cancelableWait(done, startCheck):
-		service.printf("Process started")
-		return errors.WithStack(result.error)
-	case result := <-cancelableWait(done, processFinished):
-		service.printf("Process exited")
+		logger.Printf("Process started")
 		return errors.WithStack(result.error)
 	}
 
 }
 
-func waitForLogText(line string, cancel <-chan struct{}, service *ServiceConfig) error {
+func waitForLogText(dirConfig *home.EdwardConfiguration, line string, cancel <-chan struct{}, service *services.ServiceConfig) error {
 	// Read output until we get the success
 	var t *tail.Tail
 	var err error
-	t, err = tail.TailFile(service.GetRunLog(), tail.Config{
+	t, err = tail.TailFile(service.GetRunLog(dirConfig.LogDir), tail.Config{
 		Follow: true,
 		ReOpen: true,
 		Poll:   true,
@@ -108,8 +103,7 @@ func waitForLogText(line string, cancel <-chan struct{}, service *ServiceConfig)
 
 const portStatusListen = "LISTEN"
 
-func (c *ServiceCommand) areAnyListeningPortsOpen(ports []int) (bool, error) {
-
+func areAnyListeningPortsOpen(c *instance.Instance, ports []int) (bool, error) {
 	var matchedPorts = make(map[int]struct{})
 	for _, port := range ports {
 		matchedPorts[port] = struct{}{}
@@ -129,7 +123,7 @@ func (c *ServiceCommand) areAnyListeningPortsOpen(ports []int) (bool, error) {
 	return false, nil
 }
 
-func waitForListeningPorts(ports []int, cancel <-chan struct{}, command *exec.Cmd) error {
+func waitForListeningPorts(ports []int, cancel <-chan struct{}, pid int32) error {
 	for true {
 		time.Sleep(100 * time.Millisecond)
 
@@ -163,7 +157,7 @@ func waitForListeningPorts(ports []int, cancel <-chan struct{}, command *exec.Cm
 	return errors.New("exited check loop unexpectedly")
 }
 
-func waitForAnyPort(cancel <-chan struct{}, command *exec.Cmd) error {
+func waitForAnyPort(cancel <-chan struct{}, pid int32) error {
 	for true {
 		time.Sleep(100 * time.Millisecond)
 
@@ -178,7 +172,7 @@ func waitForAnyPort(cancel <-chan struct{}, command *exec.Cmd) error {
 			return errors.WithStack(err)
 		}
 
-		proc, err := process.NewProcess(int32(command.Process.Pid))
+		proc, err := process.NewProcess(pid)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/services/groupconfig.go
+++ b/services/groupconfig.go
@@ -1,12 +1,7 @@
 package services
 
 import (
-	"fmt"
-
-	"github.com/pkg/errors"
 	"github.com/yext/edward/common"
-	"github.com/yext/edward/tracker"
-	"github.com/yext/edward/worker"
 )
 
 var _ ServiceOrGroup = &ServiceGroupConfig{}
@@ -84,95 +79,13 @@ func (c *ServiceGroupConfig) getChild(name string) ServiceOrGroup {
 	return nil
 }
 
-// Start will build and launch all services within this group
-func (c *ServiceGroupConfig) Start(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	if cfg.IsExcluded(c) {
-		return nil
+// Children returns a slice of all children of this group in the configured order
+func (c *ServiceGroupConfig) Children() []ServiceOrGroup {
+	var children []ServiceOrGroup
+	for _, name := range c.ChildOrder {
+		children = append(children, c.getChild(name))
 	}
-	groupTracker := task.Child(c.GetName())
-
-	for _, childName := range c.ChildOrder {
-		child := c.getChild(childName)
-		if child == nil {
-			return fmt.Errorf("Child not found: %s", childName)
-		}
-		err := child.Start(cfg, c.getOverrides(overrides), groupTracker, pool)
-		if err != nil {
-			// Always fail if any services in a dependant group failed
-			return errors.WithStack(err)
-		}
-	}
-	return nil
-}
-
-// Launch will launch all services within this group
-func (c *ServiceGroupConfig) Launch(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	if cfg.IsExcluded(c) {
-		return nil
-	}
-
-	groupTracker := task.Child(c.GetName())
-	for _, group := range c.Groups {
-		err := group.Launch(cfg, c.getOverrides(overrides), groupTracker, pool)
-		if err != nil {
-			// Always fail if any services in a dependant group failed
-			return errors.WithStack(err)
-		}
-	}
-	var outErr error
-	for _, service := range c.Services {
-		err := service.Launch(cfg, c.getOverrides(overrides), groupTracker, pool)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	return outErr
-}
-
-// Stop stops all services within this group
-func (c *ServiceGroupConfig) Stop(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	if cfg.IsExcluded(c) {
-		return nil
-	}
-	groupTracker := task.Child(c.GetName())
-
-	// TODO: Do this in reverse
-	for _, service := range c.Services {
-		err := service.Stop(cfg, c.getOverrides(overrides), groupTracker, pool)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	for _, group := range c.Groups {
-		err := group.Stop(cfg, c.getOverrides(overrides), groupTracker, pool)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	return nil
-}
-
-// Restart restarts all services within this group
-func (c *ServiceGroupConfig) Restart(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	if cfg.IsExcluded(c) {
-		return nil
-	}
-	groupTracker := task.Child(c.GetName())
-
-	// TODO: Do this in reverse
-	for _, service := range c.Services {
-		err := service.Restart(cfg, c.getOverrides(overrides), groupTracker, pool)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	for _, group := range c.Groups {
-		err := group.Restart(cfg, c.getOverrides(overrides), groupTracker, pool)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	return nil
+	return children
 }
 
 // IsSudo returns true if any of the services in this group require sudo to run

--- a/services/serviceconfig.go
+++ b/services/serviceconfig.go
@@ -1,28 +1,19 @@
 package services
 
 import (
-	"bufio"
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"runtime"
 	"strconv"
 	"sync"
-	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
-	"github.com/theothertomelliott/gopsutil-nocgo/net"
-	"github.com/theothertomelliott/gopsutil-nocgo/process"
 	"github.com/yext/edward/common"
-	"github.com/yext/edward/home"
-	"github.com/yext/edward/tracker"
 	"github.com/yext/edward/warmup"
-	"github.com/yext/edward/worker"
 )
 
 var _ ServiceOrGroup = &ServiceConfig{}
@@ -230,261 +221,6 @@ func (c *ServiceConfig) GetDescription() string {
 	return c.Description
 }
 
-// Launch launches this service
-func (c *ServiceConfig) Launch(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	if cfg.IsExcluded(c) {
-		return nil
-	}
-
-	command, err := c.GetCommand(overrides)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	err = pool.Enqueue(func() error {
-		return errors.WithStack(command.StartAsync(cfg, task))
-	})
-	return errors.WithStack(err)
-}
-
-// Start builds then launches this service
-func (c *ServiceConfig) Start(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	if cfg.IsExcluded(c) {
-		return nil
-	}
-
-	c.printf("Building: %s", c.Name)
-	b := NewBuilder(cfg, overrides)
-	err := b.Build(task, c)
-	if err != nil {
-		return errors.WithMessage(err, "build")
-	}
-	c.printf("Launching: %s", c.Name)
-	err = c.Launch(cfg, overrides, task, pool)
-	return errors.WithMessage(err, "launch")
-}
-
-// Stop stops this service
-func (c *ServiceConfig) Stop(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	err := pool.Enqueue(func() error {
-		return errors.WithStack(c.doStop(cfg, overrides, task))
-	})
-	return errors.WithStack(err)
-}
-
-// Restart restarts this service
-func (c *ServiceConfig) Restart(cfg OperationConfig, overrides ContextOverride, task tracker.Task, pool *worker.Pool) error {
-	var err error
-	command, err := c.GetCommand(overrides)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	overrides = command.Overrides.Merge(overrides)
-
-	err = c.doStop(cfg, overrides, task)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	if !cfg.SkipBuild {
-		b := NewBuilder(cfg, overrides)
-		err := b.Build(task, c)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
-
-	startCmd, err := c.GetCommand(overrides)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	err = startCmd.StartAsync(cfg, task)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	return nil
-}
-
-func (c *ServiceConfig) doStop(cfg OperationConfig, overrides ContextOverride, task tracker.Task) error {
-	if cfg.IsExcluded(c) {
-		return nil
-	}
-
-	if c.Commands.Launch == "" {
-		return nil
-	}
-
-	job := task.Child(c.GetName()).Child("Stop")
-	job.SetState(tracker.TaskStateInProgress)
-
-	command, err := c.GetCommand(overrides)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	if command.Pid == 0 {
-		job.SetState(tracker.TaskStateWarning, "Not running")
-		return nil
-	}
-
-	c.printf("Interrupting process for %v\n", c.Name)
-	stopped, err := c.interruptProcess(cfg, command)
-	if err != nil {
-		job.SetState(tracker.TaskStateFailed, err.Error())
-		return nil
-	}
-	c.printf("Interrupt succeeded, was process stopped? %v\n", stopped)
-
-	if !stopped {
-		c.printf("SIGINT failed to stop service, waiting for 5s before sending SIGKILL\n")
-		stopped, err := waitForTerm(command, time.Second*5)
-		if err != nil {
-			job.SetState(tracker.TaskStateFailed, err.Error())
-			return nil
-		}
-		if !stopped {
-			stopped, err := c.killProcess(cfg, command)
-			if err != nil {
-				job.SetState(tracker.TaskStateFailed, err.Error())
-				return nil
-			}
-			if stopped {
-				job.SetState(tracker.TaskStateWarning, "Killed")
-				return nil
-			}
-			job.SetState(tracker.TaskStateFailed, "Process was not killed")
-			return nil
-		}
-	}
-
-	c.printf("Cleaning up state after shutdown")
-	// Remove leftover files
-	command.clearState()
-	job.SetState(tracker.TaskStateSuccess)
-	return nil
-}
-
-func (c *ServiceConfig) interruptProcess(cfg OperationConfig, command *ServiceCommand) (success bool, err error) {
-	p, err := process.NewProcess(int32(command.Pid))
-	if err != nil {
-		return false, errors.WithStack(err)
-	}
-	err = p.SendSignal(syscall.SIGINT)
-	if err != nil {
-		return false, errors.WithStack(err)
-	}
-
-	// Check to see if the process is still running
-	exists, err := process.PidExists(int32(command.Pid))
-	if err != nil {
-		return false, errors.WithStack(err)
-	}
-	return !exists, nil
-}
-
-func (c *ServiceConfig) killProcess(cfg OperationConfig, command *ServiceCommand) (success bool, err error) {
-	pgid, err := syscall.Getpgid(command.Pid)
-	if err != nil {
-		return false, errors.WithStack(err)
-	}
-
-	if pgid == 0 || pgid == 1 {
-		return false, errors.WithStack(errors.New("suspect pgid: " + strconv.Itoa(pgid)))
-	}
-
-	err = KillGroup(cfg, pgid, c)
-	return true, errors.WithStack(err)
-}
-
-func waitForTerm(command *ServiceCommand, timeout time.Duration) (bool, error) {
-	for elapsed := time.Duration(0); elapsed <= timeout; elapsed += time.Millisecond * 100 {
-		exists, err := process.PidExists(int32(command.Pid))
-		if err != nil {
-			return false, errors.WithStack(err)
-		}
-		if !exists {
-			return true, nil
-		}
-		time.Sleep(time.Millisecond * 100)
-	}
-	return false, nil
-}
-
-func (c *ServiceConfig) getPorts(proc *process.Process) ([]string, error) {
-	ports, err := c.doGetPorts(proc)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if c.LaunchChecks != nil {
-		for _, port := range c.LaunchChecks.Ports {
-			ports = append(ports, strconv.Itoa(port))
-		}
-	}
-	return ports, nil
-}
-
-func (c *ServiceConfig) getLogCounts() (int, int) {
-	logFile, err := os.Open(c.GetRunLog())
-	if err != nil {
-		return 0, 0
-	}
-	defer logFile.Close()
-	scanner := bufio.NewScanner(logFile)
-	var stdoutCount int
-	var stderrCount int
-	var lineData struct{ Stream string }
-	for scanner.Scan() {
-		text := scanner.Text()
-		err := json.Unmarshal([]byte(text), &lineData)
-		if err != nil {
-			continue
-		}
-		if lineData.Stream == "stdout" {
-			stdoutCount++
-		}
-		if lineData.Stream == "stderr" {
-			stderrCount++
-		}
-	}
-	return stdoutCount, stderrCount
-}
-
-func (c *ServiceConfig) doGetPorts(proc *process.Process) ([]string, error) {
-	connectionsCache, err := net.Connections("all")
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	var ports []string
-	var knownPorts = make(map[int]struct{})
-	if c.LaunchChecks != nil {
-		for _, port := range c.LaunchChecks.Ports {
-			knownPorts[port] = struct{}{}
-		}
-	}
-	for _, connection := range connectionsCache {
-		if connection.Status == "LISTEN" {
-			if _, ok := knownPorts[int(connection.Laddr.Port)]; connection.Pid == proc.Pid && !ok {
-				ports = append(ports, strconv.Itoa(int(connection.Laddr.Port)))
-			}
-		}
-	}
-
-	children, err := proc.Children()
-	// This will error out if the process has finished or has no children
-	if err != nil {
-		return ports, nil
-	}
-	for _, child := range children {
-		childPorts, err := c.doGetPorts(child)
-		if err == nil {
-			ports = append(ports, childPorts...)
-		}
-	}
-	return ports, nil
-}
-
 // IsSudo returns true if this service requires sudo to run.
 // If this service is excluded by cfg, then will always return false.
 func (c *ServiceConfig) IsSudo(cfg OperationConfig) bool {
@@ -496,15 +232,8 @@ func (c *ServiceConfig) IsSudo(cfg OperationConfig) bool {
 }
 
 // GetRunLog returns the path to the run log for this service
-func (c *ServiceConfig) GetRunLog() string {
-	dir := home.EdwardConfig.LogDir
-	return path.Join(dir, c.Name+".log")
-}
-
-// GetCommand returns the ServiceCommand for this service
-func (c *ServiceConfig) GetCommand(overrides ContextOverride) (*ServiceCommand, error) {
-	command, err := LoadServiceCommand(c, overrides)
-	return command, errors.WithStack(err)
+func (c *ServiceConfig) GetRunLog(logDir string) string {
+	return path.Join(logDir, c.Name+".log")
 }
 
 // IdentifyingFilename returns a filename that can be used to identify this service uniquely among all services
@@ -518,7 +247,7 @@ func (c *ServiceConfig) IdentifyingFilename() string {
 	return fmt.Sprintf("%v.%v", sha, name)
 }
 
-func (c *ServiceConfig) getPid(command *ServiceCommand, pidFile string) (int, error) {
+func (c *ServiceConfig) GetPid(pidFile string) (int, error) {
 	dat, err := ioutil.ReadFile(pidFile)
 	if err != nil {
 		return 0, errors.WithStack(err)
@@ -530,17 +259,15 @@ func (c *ServiceConfig) getPid(command *ServiceCommand, pidFile string) (int, er
 	return pid, nil
 }
 
-func (c *ServiceConfig) getStateBase() string {
-	dir := home.EdwardConfig.StateDir
-	return path.Join(dir, c.IdentifyingFilename())
+func (c *ServiceConfig) GetStateBase(stateDir string) string {
+	return path.Join(stateDir, c.IdentifyingFilename())
 }
 
-func (c *ServiceConfig) getStatePath() string {
-	return fmt.Sprintf("%v.state", c.getStateBase())
+func (c *ServiceConfig) GetStatePath(stateDir string) string {
+	return fmt.Sprintf("%v.state", c.GetStateBase(stateDir))
 }
 
-func (c *ServiceConfig) GetPidPathLegacy() string {
-	dir := home.EdwardConfig.PidDir
+func (c *ServiceConfig) GetPidPathLegacy(pidDir string) string {
 	name := c.Name
-	return path.Join(dir, fmt.Sprintf("%v.pid", name))
+	return path.Join(pidDir, fmt.Sprintf("%v.pid", name))
 }


### PR DESCRIPTION
Break start/stop functions into the build and instance packages.
Retain the DIED state after a service/runner exits.