### PR TITLE
Autocomplete only subcommands/services at appropriate times

### DIFF
--- a/cmd/autocomplete.go
+++ b/cmd/autocomplete.go
@@ -9,8 +9,11 @@ import (
 	"github.com/yext/edward/config"
 )
 
-func autocompleteServicesAndGroups(homeDir string) {
-	printCommandChildren(RootCmd)
+func autocompleteServicesAndGroups(homeDir string, arg string) {
+	if arg == "--generate-bash-completion" {
+		printCommandChildren(RootCmd)
+		return
+	}
 
 	configPath, err := config.GetConfigPathFromWorkingDirectory(homeDir)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,7 +203,7 @@ func Execute() {
 
 	for _, arg := range os.Args {
 		if arg == "--generate-bash-completion" {
-			autocompleteServicesAndGroups(defaultHome.Dir)
+			autocompleteServicesAndGroups(defaultHome.Dir, os.Args[1])
 			return
 		}
 	}


### PR DESCRIPTION
Addresses part of issue #144 
When at subcommand stage, only autocomplete subcommands.
Afterwords, do not include subcommands in list of services/groups