### PR TITLE
When starting with backends and no groups, treat backends as services

### DIFF
--- a/edward/start.go
+++ b/edward/start.go
@@ -4,17 +4,27 @@ import (
 	"log"
 
 	"github.com/pkg/errors"
+	"github.com/yext/edward/services"
 )
 
 func (c *Client) Start(names []string, skipBuild bool, noWatch bool, exclude []string) error {
 	log.Println("Start:", names, skipBuild, noWatch, exclude)
 	if len(names) == 0 {
-		return errors.New("At least one service or group must be specified")
+		if len(c.Backends) == 0 {
+			return errors.New("At least one service or group must be specified")
+		}
 	}
 
 	sgs, err := c.getServicesOrGroups(names)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+	if startingServicesOnly(sgs) && len(c.Backends) != 0 {
+		names = append(getServiceNamesFromBackends(c), names...)
+		sgs, err = c.getServicesOrGroups(names)
+		if err != nil {
+			return errors.WithStack(err)
+		}
 	}
 	if c.ServiceChecks != nil {
 		err = c.ServiceChecks(sgs)
@@ -28,4 +38,16 @@ func (c *Client) Start(names []string, skipBuild bool, noWatch bool, exclude []s
 		return errors.WithStack(err)
 	}
 	return nil
+}
+
+func startingServicesOnly(sgs []services.ServiceOrGroup) bool {
+	return services.CountServices(sgs) == len(sgs)
+}
+
+func getServiceNamesFromBackends(c *Client) []string {
+	names := make([]string, 0, len(c.Backends))
+	for service := range c.Backends {
+		names = append(names, service)
+	}
+	return names
 }


### PR DESCRIPTION
This is a potential solution for #161 to get the ball rolling

You can now do something like 
edward start -b service:backend servicewithoutbackend