### PR TITLE
docker: Notice when container is no longer running

### DIFF
--- a/services/backends/docker/buildandrun.go
+++ b/services/backends/docker/buildandrun.go
@@ -196,6 +196,10 @@ func (b *buildandrun) Status() (services.BackendStatus, error) {
 	if err != nil {
 		errors.WithMessage(err, "pulling image")
 	}
+	if !container.State.Running {
+		close(b.done)
+		return services.BackendStatus{}, errors.New("not running")
+	}
 
 	var ports []string
 	if container.HostConfig != nil {


### PR DESCRIPTION
Aside from calling edward status, the Status function is called
frequently by the runner. We utilize that frequent call to close the done channel
which is normally done by Stop.

Probably the less hacky way to implement this is to see how commandline
deals with this scenario. (I think it might use logic in status.go getState)

See for more info: https://yext.slack.com/archives/CDW79LMCJ/p1541712100011800