### PR TITLE
Allow piped commands when "stop"ing a server

### DIFF
--- a/commandline/parse.go
+++ b/commandline/parse.go
@@ -2,6 +2,7 @@ package commandline
 
 import (
 	"fmt"
+	"strings"
 )
 
 const quotes = "quotes"
@@ -69,4 +70,12 @@ func ParseCommand(cmd string) (string, []string, error) {
 	}
 
 	return args[0], args[1:], nil
+}
+
+func TokenizeCommand(cmd string) ([]string) {
+    return strings.FieldsFunc(cmd, isSpaceOrTab)
+}
+
+func isSpaceOrTab(r rune) bool {
+    return r == ' ' || r == '\t';
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/docker/go-connections v0.3.0 // indirect
 	github.com/docker/go-units v0.3.2 // indirect
 	github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4
+	github.com/ebuchman/go-shell-pipes v0.0.0-20150412091402-83e132480862
 	github.com/fatih/color v1.6.0
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a // indirect
@@ -56,3 +57,5 @@ require (
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.6.2+incompatible h1:4FI6af79dfCS/CYb+RRtkSHw3q1L/bnDjG1PcPZtQhM=
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.3.0 h1:3lOnM9cSzgGwx8VfK/NGOW5fLQ0GjIlCkaktF+n1M6o=
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -21,6 +21,8 @@ github.com/docker/go-units v0.3.2 h1:Kjm80apys7gTtfVmCvVY8gwu10uofaFSrmAKOVrtueE
 github.com/docker/go-units v0.3.2/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4 h1:qk/FSDDxo05wdJH28W+p5yivv7LuLYLRXPPD8KQCtZs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/ebuchman/go-shell-pipes v0.0.0-20150412091402-83e132480862 h1:UdoFAkqVuHxDOaAUR/7Fkq/NZbswHya30diyAKCq4z0=
+github.com/ebuchman/go-shell-pipes v0.0.0-20150412091402-83e132480862/go.mod h1:IwOyG/0EgKg/s4V9ToqEXvObxu7iIU+/d0M4mvAowJc=
 github.com/fatih/color v1.6.0 h1:66qjqZk8kalYAvDRtM1AdAJQI0tj4Wrue3Eq3B3pmFU=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=


### PR DESCRIPTION
The current ParseCommand assumes that only one command and single
list of arguments will exist. This means that piped commands will
not work. This adds support for allowing piped commands for any
"stop" command.

Note that this does not change the build and launch commands.