### PR TITLE
Show the name of the service/group that can't be found

### DIFF
--- a/edward/config.go
+++ b/edward/config.go
@@ -58,7 +58,7 @@ func (c *Client) getServiceOrGroup(name string) (services.ServiceOrGroup, error)
 			return service, nil
 		}
 	}
-	return nil, errors.New("Service or group not found")
+	return nil, errors.Errorf("Service or group not found: %s", name)
 }
 
 // getAllGroupsSorted returns a slice of all groups, sorted by name


### PR DESCRIPTION
If interacting with multiple services, the error is less helpful than it could be