### PR TITLE
release workflow on push tags instead of create

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: 'Release'
 on:
-  create:
+  push:
     tags:
       - v*
 jobs:


### PR DESCRIPTION
`create tags` does not work well with v* match, that I verified by running a sud workflow with tag 0.4 that does not match but the release workflow was wrongly run - https://github.com/yext/sud/runs/973041620?check_suite_focus=true

Verified that this change works because the release pipeline got triggered on v0.7 but not on 0.6 tag - https://github.com/yext/sud/actions/runs/204620922